### PR TITLE
Modify package name to yelp-gprof2dot, update description and version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,6 @@ setup(
     name='yelp-gprof2dot',
     version='1.0.0',
     author='Yelp Performance Team',
-    author_email='team-perf@yelp.com',
     url='https://github.com/Yelp/gprof2dot',
     description="Generate a dot graph from the output of python profilers.",
     long_description="""

--- a/setup.py
+++ b/setup.py
@@ -15,15 +15,16 @@ import sys
 from setuptools import setup
 
 setup(
-    name='gprof2dot',
-    version='2015.02.03',
+    name='yelp-gprof2dot',
+    version='1.0.0',
     author='Jose Fonseca',
     author_email='jose.r.fonseca@gmail.com',
-    url='https://github.com/jrfonseca/gprof2dot',
-    description="Generate a dot graph from the output of several profilers.",
+    url='https://github.com/Yelp/gprof2dot',
+    description="Generate a dot graph from the output of python profilers.",
     long_description="""
-        gprof2dot.py is a Python script to convert the output from many
-        profilers into a dot graph.
+        gprof2dot.py is a Python script to convert the output from python
+        profilers (anything in pstats format) into a dot graph. It is a
+        fork of the original gprof2dot script to extend python features.
         """,
     license="LGPL",
 

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,8 @@
 # - https://code.google.com/p/jrfonseca/issues/detail?id=19
 # - http://docs.python.org/2/distutils/packageindex.html
 #
+# Original version was written by Jose Fonseca; see
+# https://github.com/jrfonseca/gprof2dot
 
 import sys
 from setuptools import setup
@@ -17,8 +19,8 @@ from setuptools import setup
 setup(
     name='yelp-gprof2dot',
     version='1.0.0',
-    author='Jose Fonseca',
-    author_email='jose.r.fonseca@gmail.com',
+    author='Yelp Performance Team',
+    author_email='team-perf@yelp.com',
     url='https://github.com/Yelp/gprof2dot',
     description="Generate a dot graph from the output of python profilers.",
     long_description="""


### PR DESCRIPTION
I'd like to get this package on our internal PyPI so I can use it easily in a service. To do that I need to change the package name. Tested this locally by installing the package via `pip install -e /path/to/working/dir` and finding the proper script in place.
