### PR TITLE
Pypi release 1.2.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,9 @@
 *.orig
 *.png
 *.pyc
+build
 dist
+venv
 !sample.png
 !tests/pstats/cProfile.orig.dot
 

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ from setuptools import setup
 
 setup(
     name='yelp-gprof2dot',
-    version='1.1.0',
+    version='1.2.0',
     author='Yelp Performance Team',
     url='https://github.com/Yelp/gprof2dot',
     description="Generate a dot graph from the output of python profilers.",


### PR DESCRIPTION
A couple of minor changes I made before the release of 1.2.0 on pypi:

* update setup.py to reference 1.2.0
* add `venv` (I used a virtualenv to build/upload packages) and `build` to `.gitignore`